### PR TITLE
forget password screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,8 +19,8 @@ class MyApp extends StatelessWidget {
       theme: ThemeData.dark(), // Dark theme for the app
       initialRoute: '/login',
       routes: {
-        '/change_pwd': (context) => ChangePass(),
         '/recover': (context) => const RecoveryCode(),
+        '/change_pwd': (context) => ChangePass(),
         '/login': (context) => const LoginScreen(),
         '/signup': (context) => const SignupScreen(),
       },


### PR DESCRIPTION
## Issue: #3 

Added two screens for recovery otp and forget password
- updated pubspec.yaml for required paths
- added necessary routes for new screens
- added route in login screen. 

![image](https://github.com/user-attachments/assets/29f56be3-e2a1-4000-b4de-21526e4d4c27)
![image](https://github.com/user-attachments/assets/e8f73c2e-2f5c-4359-8420-42a477f9d3e9)
